### PR TITLE
refactor: use uid instead of uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "remixicon": "^2.5.0",
     "simple-tmi-emotes": "^1.1.1",
     "tmi.js": "^1.8.5",
-    "uuid": "^9.0.0",
+    "uid": "^2.0.0",
     "webfontloader": "^1.6.28",
     "zod": "^3.19.1"
   },
@@ -71,7 +71,6 @@
     "@types/react-dom": "^18.0.6",
     "@types/react-resizable": "^3.0.3",
     "@types/tmi.js": "^1.8.1",
-    "@types/uuid": "^8.3.4",
     "@types/webfontloader": "^1.6.34",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",

--- a/src/pages/alert/create.tsx
+++ b/src/pages/alert/create.tsx
@@ -1,9 +1,9 @@
+import { uid } from 'uid';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { AlertElementsList } from '../../components/alert/alert-elements-list/alert-element-list';
 import { AlertSettings } from '../../components/alert/alert-settings/alert-settings';
 import { Milliseconds } from '../../types/types/custom';
-import { v4 as uuidv4 } from 'uuid';
 
 export const AlertCreate = () => {
   const [settings, setSettings] = useState<{ [x: string]: any }>({
@@ -72,7 +72,7 @@ export const AlertCreate = () => {
                 {
                   type,
                   title: 'test',
-                  id: uuidv4(),
+                  id: uid(),
                   color: '#ff0000',
                   duration: 1000,
                   startTime: 2000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1738,6 +1738,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@lukeed/csprng@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.0.1.tgz#625e93a0edb2c830e3c52ce2d67b9d53377c6a66"
+  integrity sha512-uSvJdwQU5nK+Vdf6zxcWAY2A8r7uqe+gePwLWzJ+fsQehq18pc0I2hJKwypZ2aLM90+Er9u1xn4iLJPZ+xlL4g==
+
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"
   resolved "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.22.tgz"
@@ -3565,11 +3570,6 @@
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
   integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
-
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 "@types/webfontloader@^1.6.34":
   version "1.6.34"
@@ -12497,6 +12497,13 @@ uglify-js@^3.1.4:
   resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz"
   integrity sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==
 
+uid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/uid/-/uid-2.0.0.tgz#1773bec106e96955f1658f20272e2ccea414e8bc"
+  integrity sha512-hFw+zKBA1szYdbZWj6FjTxZzJnKNf+wTDcsxlJaXS64MCy9LQEmJUVieGYHCKek/WRyFIcs0cEXtGIQmfvHe2A==
+  dependencies:
+    "@lukeed/csprng" "^1.0.0"
+
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz"
@@ -12785,11 +12792,6 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Hey there! 👋🏻 

This PR removes [`uuid`](https://bundlephobia.com/package/uuid@9.0.0) in favor of  [`uid`](https://bundlephobia.com/package/uid).
It is a 130B fast utility to randomize unique IDs of fixed length, which is what we need.

