### PR TITLE
improve a11y svg / i / button

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -17,7 +17,7 @@ export enum ButtonSize {
   Micro = 'micro',
 }
 
-export interface ButtonProps {
+export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
   color?: ButtonColor;
   size?: ButtonSize;
   children?: React.ReactNode;
@@ -48,6 +48,7 @@ export const Button = (props: ButtonProps) => {
     onClick,
     className = '',
     type = 'button',
+    ...otherProps
   } = props;
 
   const colorChoose = {
@@ -104,7 +105,7 @@ export const Button = (props: ButtonProps) => {
   }
 
   return (
-    <button onClick={onClick} className={defineClassName} type={type}>
+    <button onClick={onClick} className={defineClassName} type={type} {...otherProps}>
       {buttonContent}
     </button>
   );

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -26,14 +26,14 @@ export enum IconSVG {
   BorderRadiusBottomLeft = 'border-radius-bottom-left',
 }
 
-export interface IconSVGProps {
+export interface IconSVGProps extends React.ComponentPropsWithoutRef<'svg'> {
   width?: number;
   height?: number;
   className?: string;
   fill?: string;
 }
 
-export interface IconProps {
+export interface IconProps extends React.ComponentPropsWithoutRef<'i'> {
   name?: string;
   className?: string;
   svg?: IconSVG;
@@ -43,7 +43,16 @@ export interface IconProps {
 }
 
 export const Icon = (props: IconProps) => {
-  const { name, className = '', svg, width, height, fill } = props;
+  const {
+    name,
+    className = '',
+    svg,
+    width,
+    height,
+    fill,
+    'aria-label': ariaLabel,
+    ...otherProps
+  } = props;
 
   const svgIcon = {
     [IconSVG.Border]: (
@@ -93,5 +102,12 @@ export const Icon = (props: IconProps) => {
     return svgIcon[svg];
   }
 
-  return <i className={`ri-${name} ${className}`} role="img"></i>;
+  return (
+    <i
+      className={`ri-${name} ${className}`}
+      role="img"
+      aria-label={ariaLabel || name}
+      {...otherProps}
+    ></i>
+  );
 };

--- a/src/components/icon/icons/border-bottom.tsx
+++ b/src/components/icon/icons/border-bottom.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderBottom = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderBottom = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 20 20"
       className={className}
+      {...SVGProps}
     >
       <path
         fill={fill}

--- a/src/components/icon/icons/border-horizontal.tsx
+++ b/src/components/icon/icons/border-horizontal.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderHorizontal = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderHorizontal = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 24 24"
       className={className}
+      {...SVGProps}
     >
       <g fill={fill} clipPath="url(#clip0_809_1865)">
         <path d="M5 3H3v18h2V3zM21 3h-2v18h2V3zM17 3h-2v2h2V3zM13 3h-2v2h2V3zM13 7h-2v2h2V7zM13 11h-2v2h2v-2zM9 11H7v2h2v-2zM17 11h-2v2h2v-2zM13 15h-2v2h2v-2zM13 19h-2v2h2v-2zM17 19h-2v2h2v-2zM9 19H7v2h2v-2zM9 3H7v2h2V3z"></path>

--- a/src/components/icon/icons/border-left.tsx
+++ b/src/components/icon/icons/border-left.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderLeft = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderLeft = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 20 20"
       className={className}
+      {...SVGProps}
     >
       <path
         fill={fill}

--- a/src/components/icon/icons/border-radius-bottom-right.tsx
+++ b/src/components/icon/icons/border-radius-bottom-right.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderRadiusBottomRight = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderRadiusBottomRight = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 24 24"
       className={className}
+      {...SVGProps}
     >
       <mask
         id="mask0_762_2296"

--- a/src/components/icon/icons/border-radius-top-left.tsx
+++ b/src/components/icon/icons/border-radius-top-left.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderRadiusTopLeft = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderRadiusTopLeft = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 24 24"
       className={className}
+      {...SVGProps}
     >
       <mask
         id="mask0_762_2287"

--- a/src/components/icon/icons/border-radius-top-right.tsx
+++ b/src/components/icon/icons/border-radius-top-right.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderRadiusTopRight = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderRadiusTopRight = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 24 24"
       className={className}
+      {...SVGProps}
     >
       <mask
         id="mask0_762_2289"

--- a/src/components/icon/icons/border-radius.tsx
+++ b/src/components/icon/icons/border-radius.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderRadius = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderRadius = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 24 24"
       className={className}
+      {...SVGProps}
     >
       <path
         fill={fill}

--- a/src/components/icon/icons/border-radius_bottom-left.tsx
+++ b/src/components/icon/icons/border-radius_bottom-left.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderRadiusBottomLeft = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderRadiusBottomLeft = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 24 24"
       className={className}
+      {...SVGProps}
     >
       <mask
         id="mask0_762_2303"

--- a/src/components/icon/icons/border-right.tsx
+++ b/src/components/icon/icons/border-right.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderRight = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderRight = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 20 20"
       className={className}
+      {...SVGProps}
     >
       <path
         fill={fill}

--- a/src/components/icon/icons/border-top.tsx
+++ b/src/components/icon/icons/border-top.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderTop = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderTop = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 20 20"
       className={className}
+      {...SVGProps}
     >
       <path
         fill={fill}

--- a/src/components/icon/icons/border-vertical.tsx
+++ b/src/components/icon/icons/border-vertical.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorderVertical = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorderVertical = (props: IconSVGProps) => {
       fill="none"
       viewBox="0 0 24 24"
       className={className}
+      {...SVGProps}
     >
       <g fill={fill} clipPath="url(#clip0_809_1897)">
         <path d="M21 5V3H3v2h18zM21 21v-2H3v2h18zM21 17v-2h-2v2h2zM21 13v-2h-2v2h2zM17 13v-2h-2v2h2zM13 13v-2h-2v2h2zM13 9V7h-2v2h2zM13 17v-2h-2v2h2zM9 13v-2H7v2h2zM5 13v-2H3v2h2zM5 17v-2H3v2h2zM5 9V7H3v2h2zM21 9V7h-2v2h2z"></path>

--- a/src/components/icon/icons/border.tsx
+++ b/src/components/icon/icons/border.tsx
@@ -1,7 +1,7 @@
 import { IconSVGProps } from '../icon';
 
 export const IconBorder = (props: IconSVGProps) => {
-  const { width = 24, height = 24, className = '', fill = '#fff' } = props;
+  const { width = 24, height = 24, className = '', fill = '#fff', ...SVGProps } = props;
 
   return (
     <svg
@@ -11,6 +11,7 @@ export const IconBorder = (props: IconSVGProps) => {
       height={height}
       fill="none"
       viewBox="0 0 20 20"
+      {...SVGProps}
     >
       <path
         fill={fill}


### PR DESCRIPTION
# What does this PR do?

Add some props aiming to improve accessibility on basic `button` and `svg` `i`.
By default react don't give the props from native `html element` (mainly used on images or buttons)

Some of base component keep aving accessibility issues but they are made by radix components (with some incompatible aria label) but their not breaking because users are free to not pass these aria label

# PR Checklist
## Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] I have found someone to review this PR and pinged him

## Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
