### PR TITLE
fix(storybook): Storybook was broken since Autoimport PR

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -1,4 +1,5 @@
 const tsconfigPaths = require('vite-tsconfig-paths').default;
+const AutoImport = require('unplugin-auto-import/vite');
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -20,7 +21,12 @@ module.exports = {
       /** @see https://github.com/aleclarson/vite-tsconfig-paths */
       tsconfigPaths()
     );
-
+    config.plugins.push(
+      AutoImport({
+        imports: ['react', 'react-router-dom'],
+        dts: './src/auto-imports.d.ts',
+      })
+    );
     return config;
   },
 };


### PR DESCRIPTION
# What does this PR do?

Storybook was mainly broken since [this PR](https://github.com/Streali/App/pull/94)
Some react modules was not loaded because of this so i add it in the sb config

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] I have found someone to review this PR and pinged him

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
