### PR TITLE
feat: export element to PNG #167

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "css": "^3.0.0",
     "emmet-monaco-es": "^5.1.2",
     "framer-motion": "^7.6.19",
+    "html2canvas": "^1.4.1",
     "interactjs": "^1.10.17",
     "liquidjs": "^10.3.3",
     "logrocket": "^3.0.1",

--- a/src/components/chat/chat-card/chat-card.stories.tsx
+++ b/src/components/chat/chat-card/chat-card.stories.tsx
@@ -1,12 +1,15 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ChatCard } from './chat-card';
+import { defaultChatTheme } from '~/utils/chat/default-chat-theme';
 
 export default {
   component: ChatCard,
-  title: 'Icon',
+  title: 'ChatCard',
 } as ComponentMeta<typeof ChatCard>;
 
 const Template: ComponentStory<typeof ChatCard> = (args) => <ChatCard {...args} />;
 
 export const Primary = Template.bind({});
-Primary.args = {};
+Primary.args = {
+  theme: defaultChatTheme,
+};

--- a/src/components/chat/chat-card/chat-card.tsx
+++ b/src/components/chat/chat-card/chat-card.tsx
@@ -7,6 +7,7 @@ import { useDeleteChat } from '~/hooks/chat/use-delete-chat';
 import { useDuplicateChat } from '~/hooks/chat/use-duplicate-chat';
 import { useExportChatTheme } from '~/hooks/chat/use-export-chat';
 import type { ChatTheme } from '~/types/schemas/chat';
+import { useExportElementToPng } from '~/hooks/use-export-element-to-png';
 
 export interface ChatCardProps {
   theme: ChatTheme;
@@ -21,10 +22,14 @@ export const ChatCard = (props: ChatCardProps) => {
 
   const [menuOpen, setMenuOpen] = useState(false);
 
+  const { exportElement } = useExportElementToPng();
+  const chatRef = useRef<HTMLDivElement | null>(null);
+
   return (
     <>
       <div className=" flex h-[250px] w-full items-center justify-center overflow-hidden rounded-t-lg border border-dark-400 bg-dark-600 p-6">
         <ChatMessage
+          ref={chatRef}
           settings={theme}
           message={{
             id: '1',
@@ -90,6 +95,11 @@ export const ChatCard = (props: ChatCardProps) => {
                 onClick: () => {
                   exportChatTheme(theme);
                 },
+                icon: 'file-code-line',
+              },
+              {
+                title: 'Export to PNG',
+                onClick: () => chatRef.current && exportElement(chatRef.current),
                 icon: 'file-code-line',
               },
               {

--- a/src/components/chat/chat-message/chat-message.tsx
+++ b/src/components/chat/chat-message/chat-message.tsx
@@ -1,7 +1,7 @@
 import './chat-message.scss';
 
 import { Liquid } from 'liquidjs';
-import { Fragment } from 'react';
+import { ForwardedRef, Fragment } from 'react';
 import { scopeCSS } from '~/utils/common/scope-css';
 import { Container } from './container';
 import { Message } from './message';
@@ -13,96 +13,98 @@ export interface ChatMessageProps {
   message: TwitchMessage;
 }
 
-export const ChatMessage = memo(function ChatMessage(props: ChatMessageProps) {
-  const { settings, message } = props;
+export const ChatMessage = memo(
+  forwardRef(function ChatMessage(props: ChatMessageProps, ref: ForwardedRef<HTMLDivElement>) {
+    const { settings, message } = props;
 
-  const globalStyle = {
-    flexDirection: settings.global.layout === 'stack' ? 'column' : ('row' as 'column' | 'row'),
-    ...(settings.global.layout === 'stack' && {
-      alignItems:
-        settings.global.alignment === 'left'
-          ? 'flex-start'
-          : settings.global.alignment === 'right'
-          ? 'flex-end'
-          : ('center' as 'flex-start' | 'flex-end' | 'center'),
-    }),
-    ...(settings.global.layout === 'inline' && {
-      justifyContent:
-        settings.global.alignment === 'left'
-          ? 'flex-start'
-          : settings.global.alignment === 'right'
-          ? 'flex-end'
-          : ('center' as 'flex-start' | 'flex-end' | 'center'),
-    }),
-    marginBottom: settings.global.space_between_messages + 'px',
-  };
-
-  if (settings.global.developer_mode) {
-    const data = {
-      ...message,
-      displayBadges: function () {
-        const listBadgesUrl = Object.entries(message.badges)
-          .map(([key, value]) => {
-            if (value) {
-              return { url: `/badges/twitch/${key}.png` };
-            } else {
-              return null;
-            }
-          })
-          .filter((n) => n);
-        return listBadgesUrl;
-      },
+    const globalStyle = {
+      flexDirection: settings.global.layout === 'stack' ? 'column' : ('row' as 'column' | 'row'),
+      ...(settings.global.layout === 'stack' && {
+        alignItems:
+          settings.global.alignment === 'left'
+            ? 'flex-start'
+            : settings.global.alignment === 'right'
+            ? 'flex-end'
+            : ('center' as 'flex-start' | 'flex-end' | 'center'),
+      }),
+      ...(settings.global.layout === 'inline' && {
+        justifyContent:
+          settings.global.alignment === 'left'
+            ? 'flex-start'
+            : settings.global.alignment === 'right'
+            ? 'flex-end'
+            : ('center' as 'flex-start' | 'flex-end' | 'center'),
+      }),
+      marginBottom: settings.global.space_between_messages + 'px',
     };
 
-    const engine = new Liquid({
-      strictFilters: false,
-    });
+    if (settings.global.developer_mode) {
+      const data = {
+        ...message,
+        displayBadges: function () {
+          const listBadgesUrl = Object.entries(message.badges)
+            .map(([key, value]) => {
+              if (value) {
+                return { url: `/badges/twitch/${key}.png` };
+              } else {
+                return null;
+              }
+            })
+            .filter((n) => n);
+          return listBadgesUrl;
+        },
+      };
 
-    try {
-      const template = engine.parseAndRenderSync(settings.code?.html || '', data);
-      const style = scopeCSS(settings.code?.css || '', '[data-scope]');
+      const engine = new Liquid({
+        strictFilters: false,
+      });
 
-      return (
-        <>
-          <style>{style}</style>
-          <div dangerouslySetInnerHTML={{ __html: template }} data-scope></div>
-        </>
-      );
-    } catch (error) {
-      const err = error as Error;
-      return (
-        <div className="mb-2 rounded bg-error-500 p-1 text-xs font-bold">
-          {err.message.split(',')[0]}
-        </div>
-      );
+      try {
+        const template = engine.parseAndRenderSync(settings.code?.html || '', data);
+        const style = scopeCSS(settings.code?.css || '', '[data-scope]');
+
+        return (
+          <>
+            <style>{style}</style>
+            <div dangerouslySetInnerHTML={{ __html: template }} data-scope></div>
+          </>
+        );
+      } catch (error) {
+        const err = error as Error;
+        return (
+          <div className="mb-2 rounded bg-error-500 p-1 text-xs font-bold">
+            {err.message.split(',')[0]}
+          </div>
+        );
+      }
     }
-  }
 
-  return (
-    <div style={globalStyle} className="flex w-full">
-      <Container settings={settings} color={message.color}>
-        {settings.global.order.map((item, index) => (
-          <Fragment key={index}>
-            {item.id === 'name' && (
-              <Name
-                key={item.id}
-                settings={settings.name}
-                name={message.username}
-                badges={message.badges}
-                color={message.color}
-              />
-            )}
-            {item.id === 'message' && (
-              <Message
-                key={item.id}
-                settings={settings.message}
-                message={message.message}
-                color={message.color}
-              />
-            )}
-          </Fragment>
-        ))}
-      </Container>
-    </div>
-  );
-});
+    return (
+      <div ref={ref} style={globalStyle} className="flex w-full">
+        <Container settings={settings} color={message.color}>
+          {settings.global.order.map((item, index) => (
+            <Fragment key={index}>
+              {item.id === 'name' && (
+                <Name
+                  key={item.id}
+                  settings={settings.name}
+                  name={message.username}
+                  badges={message.badges}
+                  color={message.color}
+                />
+              )}
+              {item.id === 'message' && (
+                <Message
+                  key={item.id}
+                  settings={settings.message}
+                  message={message.message}
+                  color={message.color}
+                />
+              )}
+            </Fragment>
+          ))}
+        </Container>
+      </div>
+    );
+  })
+);

--- a/src/hooks/use-export-element-to-png.ts
+++ b/src/hooks/use-export-element-to-png.ts
@@ -1,0 +1,16 @@
+import html2canvas from 'html2canvas';
+
+export function useExportElementToPng() {
+  const exportElement = (element: HTMLDivElement) => {
+    html2canvas(element).then((canva) => {
+      const image = new Image();
+      image.src = canva.toDataURL();
+      document.body.appendChild(image);
+      image.setAttribute('download', 'image.png');
+    });
+  };
+
+  return {
+    exportElement,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5574,6 +5574,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 base64-js@^1.0.2:
   version "1.5.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
@@ -6592,6 +6597,13 @@ css-box-model@^1.2.0, css-box-model@^1.2.1:
   integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
   dependencies:
     tiny-invariant "^1.0.6"
+
+css-line-break@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-2.1.0.tgz#bfef660dfa6f5397ea54116bb3cb4873edbc4fa0"
+  integrity sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==
+  dependencies:
+    utrie "^1.0.2"
 
 css-loader@^3.6.0:
   version "3.6.0"
@@ -8768,6 +8780,14 @@ html-webpack-plugin@^4.0.0:
     pretty-error "^2.1.1"
     tapable "^1.1.3"
     util.promisify "1.0.0"
+
+html2canvas@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
+  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
 
 htmlparser2-svelte@4.1.0:
   version "4.1.0"
@@ -13312,6 +13332,13 @@ text-extensions@^1.0.0:
   resolved "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
+text-segmentation@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/text-segmentation/-/text-segmentation-1.0.3.tgz#52a388159efffe746b24a63ba311b6ac9f2d7943"
+  integrity sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==
+  dependencies:
+    utrie "^1.0.2"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
@@ -13913,6 +13940,13 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+utrie@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/utrie/-/utrie-1.0.2.tgz#d42fe44de9bc0119c25de7f564a6ed1b2c87a645"
+  integrity sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==
+  dependencies:
+    base64-arraybuffer "^1.0.2"
 
 uuid-browser@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION

# What does this PR do?

* This is just a little POC, as I'm sure how you want to use this. Right now it's just appending the image to the DOM. I think the idea is just to download the image to share it somewhere. Let me know what you have in mindd
* Add a way to export a DOM element
* fix: story for `chat-message`

![Screenshot-202301-04 at 21 04 56](https://user-images.githubusercontent.com/1261670/210640394-c0bcd450-2bbe-42a5-aab4-8938850137ae.gif)

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] I have found someone to review this PR and pinged him

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
