### PR TITLE
feat: set number of messages for chat demo #158

### DIFF
--- a/src/components/chat/chat-demo/chat-demo.stories.tsx
+++ b/src/components/chat/chat-demo/chat-demo.stories.tsx
@@ -1,0 +1,51 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ChatDemo } from '~/components/chat/chat-demo/chat-demo';
+import DemoContainer from '~/components/demo-container/demo-container';
+import { defaultChatTheme } from '~/utils/chat/default-chat-theme';
+import { Input } from '~/components/forms/input/input';
+
+export default {
+  component: ChatDemo,
+  title: 'Chat/ChatDemo',
+} as ComponentMeta<typeof ChatDemo>;
+
+interface MessagesPerMinuteFormProps {
+  value: string;
+  setValue: (value: string) => void;
+}
+
+function MessagesPerMinuteForm({ value, setValue }: MessagesPerMinuteFormProps) {
+  return (
+    <Input
+      value={value}
+      onChange={(e) => {
+        const target = e.target as HTMLInputElement;
+        setValue(target.value);
+      }}
+    />
+  );
+}
+
+const Template: ComponentStory<typeof ChatDemo> = (args) => (
+  <DemoContainer
+    tools={(demoData, setDemoData) => (
+      <>
+        <MessagesPerMinuteForm
+          setValue={(value) =>
+            setDemoData((prev) => ({ ...prev, messagesPerMinute: Number(value) }))
+          }
+          value={(demoData['messagesPerMinute'] as string) ?? '1250'}
+        />
+      </>
+    )}
+  >
+    {(demoData) => (
+      <ChatDemo timeBetweenMessages={(demoData.messagesPerMinute as number) ?? 1_250} {...args} />
+    )}
+  </DemoContainer>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  settings: defaultChatTheme,
+};

--- a/src/components/chat/chat-demo/chat-demo.tsx
+++ b/src/components/chat/chat-demo/chat-demo.tsx
@@ -5,6 +5,7 @@ import type { ChatTheme, TwitchMessage } from '~/types/schemas/chat';
 
 export interface ChatDemoProps {
   settings: Omit<ChatTheme, 'user_id' | 'id'> | ChatTheme;
+  timeBetweenMessages?: number;
 }
 
 export const ChatDemo = (props: ChatDemoProps) => {
@@ -12,6 +13,7 @@ export const ChatDemo = (props: ChatDemoProps) => {
   const [messages, setMessages] = useState<TwitchMessage[]>([]);
 
   useEffect(() => {
+    const timeBetweenMessages = Math.max(250, props.timeBetweenMessages ?? 1250);
     const interval = setInterval(
       () =>
         setMessages((d) => {
@@ -19,11 +21,11 @@ export const ChatDemo = (props: ChatDemoProps) => {
           const newMessage: TwitchMessage = generateTwitchMessage();
           return [...d, newMessage];
         }),
-      1250
+      timeBetweenMessages
     );
 
     return () => clearInterval(interval);
-  }, []);
+  }, [props.timeBetweenMessages]);
 
   return (
     <>

--- a/src/components/demo-container/demo-container.tsx
+++ b/src/components/demo-container/demo-container.tsx
@@ -1,14 +1,20 @@
 import { Color } from '../forms/color/color';
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
 
 export type DemoContainerProps = {
-  children: React.ReactNode;
+  children: (demoData: Record<string, unknown>) => ReactNode;
   className?: string;
   isDeveloperMode?: boolean;
+  tools?: (
+    demoData: Record<string, unknown>,
+    setDemoDat: Dispatch<SetStateAction<Record<string, unknown>>>
+  ) => void;
 };
 
 const DemoContainer = (props: DemoContainerProps) => {
   const { children, isDeveloperMode } = props;
   const [color, setColor] = useState<string>('#040508');
+  const [demoData, setDemoData] = useState<Record<string, unknown>>({});
 
   return (
     <div
@@ -17,9 +23,10 @@ const DemoContainer = (props: DemoContainerProps) => {
         isDeveloperMode ? 'h-[calc(100vh_-_470px)]' : 'h-[calc(100vh_-_80px)]'
       }`}
     >
-      {children}
-      <div className="absolute inset-0  flex h-14 w-full items-center justify-end bg-dark-600/40 px-2 backdrop-blur-sm">
+      {typeof children === 'function' ? children(demoData) : children}
+      <div className="absolute inset-0 flex  h-14 w-full items-center justify-end space-x-4 bg-dark-600/40 px-2 backdrop-blur-sm">
         <Color haveInput={false} value={color} onColorChange={setColor} />
+        <>{props.tools && props.tools(demoData, setDemoData)}</>
       </div>
     </div>
   );


### PR DESCRIPTION
# What does this PR do?

Add a way to increase the number of messages in the ChatDemo component.

I mentioned in the original ticket #158, that I'm not sure what you want in terms of UI.

> Screenshot of the feature

![Screenshot-202301-05 at 21 41 03](https://user-images.githubusercontent.com/1261670/210876969-40df075d-75cd-41e3-a454-ea0177aee393.gif)

---

## PR Checklist

### Global

- [ ] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] I have found someone to review this PR and pinged him

### Clean Code

- [ ] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
