### PR TITLE
feat: refresh human timestamp on events list #170

### DIFF
--- a/src/components/event/event.stories.tsx
+++ b/src/components/event/event.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Button } from '~/components/button/button';
 import { Event } from './event';
 
 export default {
@@ -13,7 +12,7 @@ export const Primary = Template.bind({});
 Primary.args = {
   event: {
     id: '123',
-    created_at: '2021-01-01T00:00:00.000Z',
+    created_at: new Date().toString(),
     type: 10,
     payload: {
       displayName: 'WillTraore',

--- a/src/components/event/event.tsx
+++ b/src/components/event/event.tsx
@@ -93,6 +93,16 @@ export const Event = (props: EventProps) => {
 
   const { mutate: replay } = useReplayEvent();
 
+  const [humanCreatedAt, setHumanCreated] = useState(HumanDate(event.created_at));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setHumanCreated(HumanDate(event.created_at));
+    }, 1000 * 60 * 2);
+
+    return () => clearInterval(interval);
+  }, [event]);
+
   return (
     <>
       <div className="flex w-full items-center divide-x divide-dark-300 border-b border-dark-300 bg-dark-400 py-2 first-of-type:rounded-t-lg last-of-type:rounded-b-lg last-of-type:border-b-0">
@@ -100,7 +110,7 @@ export const Event = (props: EventProps) => {
           {EventTypeText[event.type]}
         </span>
 
-        <div className="w-9 shrink-0 text-center text-dark-100">{HumanDate(event.created_at)}</div>
+        <div className="w-9 shrink-0 text-center text-dark-100">{humanCreatedAt}</div>
 
         <div className="flex-grow px-3">
           {EventTypeMessage[event.type](event.payload as any)}


### PR DESCRIPTION
# What does this PR do?

Refresh the human timestamp on the events list

> Screenshot of the feature

I couldn't provide a screenshot, because the item is updating every minute

---

## PR Checklist

### Global

- [x] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] I have found someone to review this PR and pinged him

### Clean Code

- [x] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
