### PR TITLE
feat: add emotes to chat-demo #175

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-router-dom": "^6.4.5",
     "react-select": "^5.7.0",
     "remixicon": "^2.5.0",
+    "simple-tmi-emotes": "^1.1.1",
     "uid": "^2.0.1",
     "zod": "^3.19.1"
   },

--- a/src/components/chat/chat-demo/chat-demo.stories.tsx
+++ b/src/components/chat/chat-demo/chat-demo.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ChatDemo } from '~/components/chat/chat-demo/chat-demo';
+import DemoContainer from '~/components/demo-container/demo-container';
+import { defaultChatTheme } from '~/utils/chat/default-chat-theme';
+
+export default {
+  component: ChatDemo,
+  title: 'Chat/ChatDemo',
+} as ComponentMeta<typeof ChatDemo>;
+
+const Template: ComponentStory<typeof ChatDemo> = (args) => (
+  <DemoContainer>
+    <ChatDemo {...args} />
+  </DemoContainer>
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  settings: defaultChatTheme,
+};

--- a/src/utils/chat/generate-chat-message.ts
+++ b/src/utils/chat/generate-chat-message.ts
@@ -4,7 +4,16 @@ import type { TwitchMessage } from '~/types/schemas/chat';
 
 export const randomMessages = [
   {
-    message: 'Hello',
+    message: ':):)',
+    emotes: {
+      '1': ['0-1', '2-3'],
+    },
+  },
+  {
+    message: 'Hello HeyGuys',
+    emotes: {
+      '30259': ['6-12'],
+    },
   },
   {
     message: 'Are you sure? Kappa',
@@ -12,19 +21,24 @@ export const randomMessages = [
       '25': ['14-19'],
     },
   },
-
   {
     message: 'How are you?',
   },
   {
-    message: 'What are you doing?',
+    message: 'What are you doing? NotLikeThis',
+    emotes: {
+      '58765': ['20-30'],
+    },
   },
   {
     message:
       "They say that dogs are man's best friend, but this cat was setting out to sabotage that theory.",
   },
   {
-    message: 'It is beneficial for them to work with eachother.',
+    message: 'It is beneficial for them to work with each other LUL',
+    emotes: {
+      '425618': ['50-60'],
+    },
   },
   {
     message: 'I have been busier these days due to having a lot on my plate.',

--- a/src/utils/chat/generate-chat-message.ts
+++ b/src/utils/chat/generate-chat-message.ts
@@ -1,27 +1,76 @@
 import chance from 'chance';
+import { parse } from 'simple-tmi-emotes';
 import type { TwitchMessage } from '~/types/schemas/chat';
 
 export const randomMessages = [
-  'Hello',
-  'How are you?',
-  'What are you doing?',
-  "They say that dogs are man's best friend, but this cat was setting out to sabotage that theory.",
-  'It is beneficial for them to work with eachother.',
-  'I have been busier these days due to having a lot on my plate.',
-  'Norrin Radd has cosmic awareness.',
-  'They are widely known around the planet.',
-  'This picture is truly beautiful.',
-  'This place is full of smart people.',
-  'Her favorite color is black.',
-  'The cell phone is next to the laptop.',
-  "Barry Allen's movement is the fastest on the planet.",
-  'They stated an opinion on how they felt.',
-  'I am thinking positively about the future.',
-  'His jokes were funny.',
-  'His question is confusing.',
-  "Please don't be rude.",
-  'I am going to the store.',
-  'Her presentation was good enough for me personally.',
+  {
+    message: 'Hello',
+  },
+  {
+    message: 'Are you sure? Kappa',
+    emotes: {
+      '25': ['14-19'],
+    },
+  },
+
+  {
+    message: 'How are you?',
+  },
+  {
+    message: 'What are you doing?',
+  },
+  {
+    message:
+      "They say that dogs are man's best friend, but this cat was setting out to sabotage that theory.",
+  },
+  {
+    message: 'It is beneficial for them to work with eachother.',
+  },
+  {
+    message: 'I have been busier these days due to having a lot on my plate.',
+  },
+  {
+    message: 'Norrin Radd has cosmic awareness.',
+  },
+  {
+    message: 'They are widely known around the planet.',
+  },
+  {
+    message: 'This picture is truly beautiful.',
+  },
+  {
+    message: 'This place is full of smart people.',
+  },
+  {
+    message: 'Her favorite color is black.',
+  },
+  {
+    message: 'The cell phone is next to the laptop.',
+  },
+  {
+    message: "Barry Allen's movement is the fastest on the planet.",
+  },
+  {
+    message: 'They stated an opinion on how they felt.',
+  },
+  {
+    message: 'I am thinking positively about the future.',
+  },
+  {
+    message: 'His jokes were funny.',
+  },
+  {
+    message: 'His question is confusing.',
+  },
+  {
+    message: "Please don't be rude.",
+  },
+  {
+    message: 'I am going to the store.',
+  },
+  {
+    message: 'Her presentation was good enough for me personally.',
+  },
 ];
 
 export const generateMessage = () => {
@@ -83,13 +132,18 @@ export const generateColor = () => {
 };
 
 export const generateTwitchMessage = (): TwitchMessage => {
+  const { message, emotes } = generateMessage();
   return {
     id: chance().guid(),
     username: generateUsername(),
     twitch: chance().guid(),
-    emotes: {},
+    emotes,
     date: new Date(),
-    message: generateMessage(),
+    message: parse(message, emotes ?? {}, {
+      format: 'default',
+      themeMode: 'light',
+      scale: '2.0',
+    }),
     badges: chance().integer({ min: 1, max: 2 }) == 1 ? generateBadges() : defaultBadges,
     mod: false,
     subscriber: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9709,6 +9709,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
+lodash.escape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
+  integrity sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==
+
 lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
@@ -12535,6 +12540,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+simple-tmi-emotes@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/simple-tmi-emotes/-/simple-tmi-emotes-1.1.1.tgz#ac7ba0042fa87dd498421ab88110ddd3b22aeb31"
+  integrity sha512-GzF7JLLBD/cV5VZCd02qL5zoEI9W/VTzAcOVRKVLobJoPWT3R2FldvHwHu8PEQhoeJj1hcrL/QMi6y+AJv1vHw==
+  dependencies:
+    lodash.escape "^4.0.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
# What does this PR do?

Add emotes to ChatDemo. There are multiple ways of implementing this. I feel like adding back `simple-tmi-emotes` is helpful to reproduce actual usage.

Let me know what you think :)

> Screenshot of the feature

<img width="565" alt="Screenshot-202301-07 at 21 04 18@2x" src="https://user-images.githubusercontent.com/1261670/211168540-33e44aa7-86d5-4d56-908b-172f6779aa6c.png">


---

## PR Checklist

### Global

- [ ] This PR does not introduce any breaking change
- [ ] This PR introduces breaking change(s) and has been labeled as such
- [ ] I have found someone to review this PR and pinged him

### Clean Code

- [ ] I made sure the code is type safe (no any)
- [ ] I have included a feature flag on my feature, if applicable
